### PR TITLE
Fixed references to project_name where it should have been project_slug

### DIFF
--- a/{{cookiecutter.project_name}}/.travis.yml
+++ b/{{cookiecutter.project_name}}/.travis.yml
@@ -16,7 +16,7 @@ env:
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
 - pip install -U poetry
-- pip install -U tox-travis 
+- pip install -U tox-travis
 
 
 # Command to run tests, e.g. python setup.py test
@@ -37,7 +37,7 @@ deploy:
   script: poetry publish
   on:
     tags: true
-    repo: {{ cookiecutter.github_username }}/{{ cookiecutter.project_name }}
+    repo: {{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
     branch: master
     python: 3.6
 {%- endif %}

--- a/{{cookiecutter.project_name}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.project_name}}/CONTRIBUTING.rst
@@ -62,7 +62,7 @@ Ready to contribute? Here's how to set up `{{ cookiecutter.project_name }}` for 
 1. Fork the `{{ cookiecutter.project_name }}` repo on GitHub.
 2. Clone your fork locally::
 
-    $ git clone git@github.com:your_name_here/{{ cookiecutter.project_name }}.git
+    $ git clone git@github.com:your_name_here/{{ cookiecutter.project_slug }}.git
 
 3. Install your local copy into a virtualenv using poetry. Assuming you have poetry installed, this is how you set up your fork for local development::
 

--- a/{{cookiecutter.project_name}}/README.rst
+++ b/{{cookiecutter.project_name}}/README.rst
@@ -8,13 +8,13 @@
         :target: https://pypi.python.org/pypi/{{ cookiecutter.project_slug }}
 
 {% if cookiecutter.use_pypi_deployment_with_travis -%}
-.. image:: https://img.shields.io/travis/{{ cookiecutter.github_username }}/{{ cookiecutter.project_name }}.svg
-        :target: https://travis-ci.org/{{ cookiecutter.github_username }}/{{ cookiecutter.project_name }}
+.. image:: https://img.shields.io/travis/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}.svg
+        :target: https://travis-ci.org/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
 {%- endif %}
 
 {% if cookiecutter.use_pypi_deployment_with_appveyor -%}
 .. image:: https://ci.appveyor.com/api/projects/status/{{ cookiecutter.github_username }}/branch/master?svg=true
-    :target: https://ci.appveyor.com/project/{{ cookiecutter.github_username }}/{{ cookiecutter.project_name }}/branch/master
+    :target: https://ci.appveyor.com/project/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/branch/master
     :alt: Build status on Appveyor
 {%- endif %}
 
@@ -24,8 +24,8 @@
 {%- endif %}
 
 {% if cookiecutter.add_pyup_badge == 'y' %}
-.. image:: https://pyup.io/repos/github/{{ cookiecutter.github_username }}/{{ cookiecutter.project_name }}/shield.svg
-     :target: https://pyup.io/repos/github/{{ cookiecutter.github_username }}/{{ cookiecutter.project_name }}/
+.. image:: https://pyup.io/repos/github/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/shield.svg
+     :target: https://pyup.io/repos/github/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/
      :alt: Updates
 {% endif %}
 
@@ -37,7 +37,7 @@
 {% if cookiecutter.document_publisher == 'ReadTheDocs' %}
 * Documentation: https://{{ cookiecutter.project_slug | replace("_", "-") }}.readthedocs.io.
 {% else %}
-* Documentation: https://{{ cookiecutter.github_username}}.github.io/{{ cookiecutter.project_name }}
+* Documentation: https://{{ cookiecutter.github_username}}.github.io/{{ cookiecutter.project_slug }}
 {% endif %}
 {% endif %}
 
@@ -46,7 +46,7 @@ Installation:
 
 .. code-block:: console
 
-    $ pip install {{ cookiecutter.project_name }}
+    $ pip install {{ cookiecutter.project_slug }}
 
 Features
 --------

--- a/{{cookiecutter.project_name}}/docs/installation.rst
+++ b/{{cookiecutter.project_name}}/docs/installation.rst
@@ -12,7 +12,7 @@ To install {{ cookiecutter.project_name }}, run this command in your terminal:
 
 .. code-block:: console
 
-    $ pip install {{ cookiecutter.project_name }}
+    $ pip install {{ cookiecutter.project_slug }}
 
 This is the preferred method to install {{ cookiecutter.project_name }}, as it will always install the most recent stable release.
 
@@ -32,13 +32,13 @@ You can either clone the public repository:
 
 .. code-block:: console
 
-    $ git clone git://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_name }}
+    $ git clone git://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
 
 Or download the `tarball`_:
 
 .. code-block:: console
 
-    $ curl  -OL https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_name }}/tarball/master
+    $ curl  -OL https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/tarball/master
 
 Once you have a copy of the source, you can install into poetry virtual environment with:
 
@@ -47,5 +47,5 @@ Once you have a copy of the source, you can install into poetry virtual environm
     $ poetry install
 
 
-.. _Github repo: https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_name }}
-.. _tarball: https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_name }}/tarball/master
+.. _Github repo: https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
+.. _tarball: https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/tarball/master

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "{{ cookiecutter.project_name }}"
+name = "{{ cookiecutter.project_slug }}"
 version = "{{ cookiecutter.version }}"
 description = "{{ cookiecutter.project_short_description }}"
 authors = ["{{ cookiecutter.full_name }} <{{ cookiecutter.email }}>"]
@@ -7,11 +7,11 @@ license = "{{ cookiecutter.open_source_license }}"
 
 readme = "README.rst"
 
-repository = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_name }}"
+repository = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}"
 {% if cookiecutter.document_publisher == 'ReadTheDocs' %}
 homepage = https://{{ cookiecutter.project_slug | replace("_", "-") }}.readthedocs.io.
 {% else %}
-homepage = "https://{{ cookiecutter.github_username }}.github.io/{{ cookiecutter.project_name }}"
+homepage = "https://{{ cookiecutter.github_username }}.github.io/{{ cookiecutter.project_slug }}"
 {%- endif %}
 
 packages = [


### PR DESCRIPTION
In several places, the template resolves `cookiecutter.project_name` instead of `cookiecutter.project_slug`. This should fix it.